### PR TITLE
Acceptable Use Policy

### DIFF
--- a/aup.md
+++ b/aup.md
@@ -39,7 +39,7 @@ You are **solely responsible** for the content you contribute to the Repository 
 - You own or have the necessary rights to use and submit the content in question.
 - Your content does not violate any applicable laws, regulations, or third-party rights, including intellectual property rights.
 - Your content does not contain any harmful or malicious code that could impact the operation of the Repository or harm other Users.
-- Your content is not prohibited content under clause 1 above and also is not intended for the purposes of prohibited activities under clause 2 above does not violate any other provision of this policy.
+- Your content is not prohibited content under clause 1 above and also is not intended for the purposes of prohibited activities under clause 2 above, and does not violate any other provision of this policy.
 
 **You acknowledge and agree that the neither the Repository Administrators, nor Moderators, whether collectively or individually, are not responsible for the content you or others contribute to the Repository, and they shall not be held liable for any damages or losses resulting from such content.**
 

--- a/aup.md
+++ b/aup.md
@@ -1,0 +1,85 @@
+---
+title: "Acceptable Use Policy"
+---
+
+The terms "R-multiverse", "User", "Contributor", "Moderator" and "Administrator" are as defined in the [R-multiverse Governance Document](governance.md).
+This Acceptable Use Policy (the "Policy") outlines the standards of conduct expected from all Users and Contributors to R-multiverse (the "Repository").
+By accessing or using the Repository, you agree to comply with this Policy.
+Violations of this Policy may result in the suspension or termination of your access to the Repository.
+
+## 1. Prohibited Content
+
+Users and Contributors must not submit, post, or share any content that:
+
+- **Illegal or Unlawful**: Violates any applicable laws, regulations, or guidelines in your jurisdiction, including content that promotes illegal activities, constitutes fraud, or violates intellectual property rights.
+- **Malicious Software**: Contains viruses, malware, ransomware, trojan horses, or any other harmful or malicious code designed to disrupt, damage, or interfere with the proper functioning of any software, hardware, or network.
+- **Harassment and Hate Speech**: Includes language or content that is abusive, defamatory, harassing, discriminatory, threatening, or hateful based on race, gender, ethnicity, religion, disability, sexual orientation, or any other protected characteristic.
+- **Spam and Unsolicited Messages**: Involves sending unsolicited messages, advertising, promotional materials, or any form of spam not directly related to the technical content of the Repository.
+
+## 2. Prohibited Activities
+
+Users and Contributors are prohibited from engaging in activities that:
+
+- **Unauthorized Access**: Attempt to gain unauthorized access to the Repository or any associated systems, networks, or data.
+- **Disruption of Services**: Interfere with or disrupt the operation of the Repository, including launching denial-of-service attacks or other harmful activities.
+- **Circumventing Security Measures**: Attempt to bypass or disable any security or authentication measures implemented by the Repository administrators.
+- **Data Harvesting**: Use any automated system, including "bots", "scrapers", or other similar data-gathering tools, to extract data from the Repository for unauthorized purposes.
+
+## 3. Responsibility for Contributed Content
+
+You are **solely responsible** for the content you contribute to the Repository and for any harm or liability that results from such content. This includes, but is not limited to, code, documentation, comments, and any other materials you post. By submitting content to the Repository, you represent and warrant that:
+
+- You own or have the necessary rights to use and submit the content in question.
+- Your content does not violate any applicable laws, regulations, or third-party rights, including intellectual property rights.
+- Your content does not contain any harmful or malicious code that could impact the operation of the Repository or harm other Users.
+
+**You acknowledge and agree that the neither the Repository Administrators, nor Moderators, whether collectively or individually, are not responsible for the content you or others contribute to the Repository, and they shall not be held liable for any damages or losses resulting from such content.**
+
+## 4. Privacy and Misuse of Personal Information
+
+- **Personal Data**: You must not collect, store, or share personal information from other Users of the Repository without their explicit consent.
+Personal information includes, but is not limited to, names, addresses, email addresses, and any other data that can identify an individual.
+- **Misuse of Personal Information**: You are prohibited from using personal information obtained through the Repository for any unlawful, unauthorized, or unethical purposes, including harassment, spamming, identity theft, or any form of misuse.
+- **Data Protection**: You agree to comply with all applicable data protection and privacy laws, including the General Data Protection Regulation (GDPR), the California Consumer Privacy Act (CCPA), and any other relevant regulations governing the processing and protection of personal data.
+
+## 5. User Safety and Protection
+
+- **Respectful Environment**: The Repository is committed to maintaining a safe and respectful environment. All Users, Contributors, Moderators and Administrators must adhere to the Repository's [Code of Conduct](conduct.md), which sets the standards for respectful interactions and community behavior.
+- **Threats and Violence**: You must not make threats of violence or promote violence against any individual or group of individuals. Any behavior that poses a risk to the safety or well-being of others will be taken seriously and may result in immediate removal from the Repository.
+- **Zero Tolerance for Hate Speech**: Hate speech, which includes any content that incites hatred or discrimination against individuals or groups based on race, ethnicity, national origin, gender, gender identity, sexual orientation, religion, disability, or any other characteristic, is strictly forbidden.
+
+## 6. Export Controls and Sanctions Compliance
+
+You agree to comply with all applicable laws regarding the export of software and technical data, including, but not limited to, the export control laws and regulations of your jurisdictions. By using the Repository, you represent and warrant that:
+
+- **Prohibited Destinations**: You will not transfer, export, re-export, or download any software or technical data made available through the Repository to any individual, entity, or country where such export is restricted or prohibited by applicable laws.
+- **Compliance Responsibility**: It is your responsibility to understand and comply with the relevant export control and sanctions laws pertaining to you before using, contributing to, or downloading content from the Repository.
+
+## 7. Intellectual Property
+
+Contributors must ensure that any code, documentation, or content they submit to the Repository is their own original work or that they have obtained all necessary permissions to use and share the content.
+Submissions must not infringe on the copyrights, trademarks, or other intellectual property rights of third parties.
+
+## 8. Enforcement and Reporting Violations
+
+Administrators and Moderators of the Repository reserve the right to take appropriate actions to enforce this Policy, including but not limited to:
+
+- Removing or modifying content that violates this Policy.
+- Temporarily or permanently suspending access to the Repository for Users and Contributors who breach this Policy.
+- Reporting unlawful activities to law enforcement authorities.
+
+If you believe someone has violated this Policy or you encounter any inappropriate content on the Repository, please report it immediately to the Repository Administrators.
+
+## 9. Indemnification
+
+You agree to indemnify and hold harmless the Repository Administrators and Moderators, collectively and individually, from any claims, liabilities, damages, losses, and expenses, including legal fees, arising out of or in any way connected with your violation of this Policy.
+
+## 10. Right to Modify Policy
+
+The Administrators of the Repository reserve the right to modify or update this Acceptable Use Policy at any time, in accordance with the procedures set out in the [R-multiverse Governance Document](governance.md).
+Your continued use of the Repository following any changes constitutes your acceptance of the revised Policy.
+
+## 11. Disclaimer of Liability
+
+The Repository Administrators and Moderators, collectively and individually, shall not be held liable for any content posted by Users or Contributors.
+All content in the Repository is provided "as-is", and the Administrators and Moderators, collectively and individually, disclaim any responsibility for damages or losses resulting from content submitted by Users or Contributors.

--- a/aup.md
+++ b/aup.md
@@ -39,7 +39,7 @@ You are **solely responsible** for the content you contribute to the Repository 
 - You own or have the necessary rights to use and submit the content in question.
 - Your content does not violate any applicable laws, regulations, or third-party rights, including intellectual property rights.
 - Your content does not contain any harmful or malicious code that could impact the operation of the Repository or harm other Users.
-- Your content is not prohibited content under clause 1 above and also is not intended for the purposes of prohibited activities under clause 2 above, and does not violate any other provision of this policy.
+- Your content abides by all R-multiverse policies, including but not limited to clause 1 (Prohibited Content) and clause 2 (Prohibited Activities) of this policy.
 
 **You acknowledge and agree that the neither the Repository Administrators, nor Moderators, whether collectively or individually, are not responsible for the content you or others contribute to the Repository, and they shall not be held liable for any damages or losses resulting from such content.**
 

--- a/aup.md
+++ b/aup.md
@@ -15,6 +15,7 @@ Users and Contributors must not submit, post, or share any content that:
 
 - **Illegal or Unlawful**: Violates any applicable laws, regulations, or guidelines in your jurisdiction, including content that promotes illegal activities, constitutes fraud, or violates intellectual property rights.
 - **Malicious Software**: Contains viruses, malware, ransomware, trojan horses, or any other harmful or malicious code designed to disrupt, damage, or interfere with the proper functioning of any software, hardware, or network.
+- **Sabotage and Cyberattacks**: Engages in or supports any form of sabotage or cyberattack, including but not limited to attacks on research, infrastructure, or industrial control systems of any third party.
 - **Harassment and Hate Speech**: Includes language or content that is abusive, defamatory, harassing, discriminatory, threatening, or hateful based on race, gender, ethnicity, religion, disability, sexual orientation, or any other protected characteristic.
 - **Violence**: Promotes, organizes, threatens, encourages, glorifies, or incites violence of any kind, including threats of harm or abuse or incitement of self-harm.
 - **Obscenity**: Is explicit, graphic, exploitative, abusive, or deliberately profane, sexually or otherwise, including but not limited to cases where minors are concerned.

--- a/aup.md
+++ b/aup.md
@@ -39,6 +39,7 @@ You are **solely responsible** for the content you contribute to the Repository 
 - You own or have the necessary rights to use and submit the content in question.
 - Your content does not violate any applicable laws, regulations, or third-party rights, including intellectual property rights.
 - Your content does not contain any harmful or malicious code that could impact the operation of the Repository or harm other Users.
+- Your content is not prohibited content under clause 1 above and also is not intended for the purposes of prohibited activities under clause 2 above does not violate any other provision of this policy.
 
 **You acknowledge and agree that the neither the Repository Administrators, nor Moderators, whether collectively or individually, are not responsible for the content you or others contribute to the Repository, and they shall not be held liable for any damages or losses resulting from such content.**
 

--- a/aup.md
+++ b/aup.md
@@ -2,7 +2,7 @@
 title: "Acceptable Use Policy"
 ---
 
-The terms "R-multiverse", "User", "Contributor", "Moderator" and "Administrator" are as defined in the [R-multiverse Governance Document](governance.md).
+The terms "R-multiverse", "User", "Contributor", "Moderator" and "Administrator" shall have the meaning as defined in the [R-multiverse Governance Document](governance.md).
 This Acceptable Use Policy (the "Policy") outlines the standards of conduct expected from all Users and Contributors to R-multiverse (the "Repository").
 By accessing or using the Repository, you agree to comply with this Policy.
 Violations of this Policy may result in the suspension or termination of your access to the Repository.

--- a/aup.md
+++ b/aup.md
@@ -16,7 +16,11 @@ Users and Contributors must not submit, post, or share any content that:
 - **Illegal or Unlawful**: Violates any applicable laws, regulations, or guidelines in your jurisdiction, including content that promotes illegal activities, constitutes fraud, or violates intellectual property rights.
 - **Malicious Software**: Contains viruses, malware, ransomware, trojan horses, or any other harmful or malicious code designed to disrupt, damage, or interfere with the proper functioning of any software, hardware, or network.
 - **Harassment and Hate Speech**: Includes language or content that is abusive, defamatory, harassing, discriminatory, threatening, or hateful based on race, gender, ethnicity, religion, disability, sexual orientation, or any other protected characteristic.
+- **Violence**: Promotes, organizes, threatens, encourages, glorifies, or incites violence of any kind, including threats of harm or abuse or incitement of self-harm.
+- **Obscenity**: Is explicit, graphic, exploitative, abusive, or deliberately profane, sexually or otherwise, including but not limited to cases where minors are concerned.
 - **Spam and Unsolicited Messages**: Involves sending unsolicited messages, advertising, promotional materials, or any form of spam not directly related to the technical content of the Repository.
+- **Privacy**: Reveals personal information of others without their consent, including but not limited to private email addresses, phone numbers, physical addresses, bank account or credit card information, social security or national identity numbers, passwords, voter information, medical information and other private information whose disclosure is a safety or security risk.
+- **Impersonation**: Misrepresents your identity or affiliation, or that of another person or organization.
 
 ## 2. Prohibited Activities
 

--- a/aup.md
+++ b/aup.md
@@ -13,7 +13,7 @@ Violations of this Policy may result in the suspension or termination of your ac
 
 Users and Contributors must not submit, post, or share any content that:
 
-- **Illegal or Unlawful**: Violates any applicable laws, regulations, or guidelines in your jurisdiction, including content that promotes illegal activities, constitutes fraud, or violates intellectual property rights.
+- **Illegal or Unlawful**: Violates any applicable laws, including content that promotes illegal activities, constitutes fraud, or violates intellectual property rights or other laws, regulations, and guidelines in your jurisdiction.
 - **Malicious Software**: Contains viruses, malware, ransomware, trojan horses, or any other harmful or malicious code designed to disrupt, damage, or interfere with the proper functioning of any software, hardware, or network.
 - **Sabotage and Cyberattacks**: Engages in or supports any form of sabotage or cyberattack, including but not limited to attacks on research, infrastructure, or industrial control systems of any third party.
 - **Harassment and Hate Speech**: Includes language or content that is abusive, defamatory, harassing, discriminatory, threatening, or hateful based on race, gender, ethnicity, religion, disability, sexual orientation, or any other protected characteristic.

--- a/aup.md
+++ b/aup.md
@@ -4,6 +4,8 @@ title: "Acceptable Use Policy"
 
 The terms "R-multiverse", "User", "Contributor", "Moderator" and "Administrator" shall have the meaning as defined in the [R-multiverse Governance Document](governance.md).
 This Acceptable Use Policy (the "Policy") outlines the standards of conduct expected from all Users and Contributors to R-multiverse (the "Repository").
+The term "You" or "Your" refers to any individual or entity that accesses, uses, contributes to, or interacts with R-multiverse, including but not limited to Users and Contributors.
+
 By accessing or using the Repository, you agree to comply with this Policy.
 Violations of this Policy may result in the suspension or termination of your access to the Repository.
 


### PR DESCRIPTION
Closes https://github.com/r-multiverse/help/issues/88.

This document is designed to protect Administrators and Moderators from Content and Behaviour of Contributors and Users. It references the Code of Conduct.

This is as distinct from the Terms of Use, which is designed to protect Administrators, Moderators and Contributors from claims by Users.

A combination of the Terms of Use, this AUP, and the Code of Conduct creates a multi-layered approach that is more comprehensive than relying on a single document.

Review and comments welcome.