### PR TITLE
Add private repo to report policy violations

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -66,8 +66,14 @@ The R-multiverse project is managed through a collaborative, consensus-based app
 
 Communication is always done publicly via GitHub, and all decisions related to the project are made in public.
 
-An exception exists for confidential security and conduct-related matters, for which there is a private GitHub repository accessible by administrators only.
-The use of this private repository ensures that even confidential conversations remain accountable and open to audit.
+Exceptions exists for:
+
+1. Confidential security and conduct-related matters, for which there is a private GitHub repository accessible by administrators only.
+1. Reporting, tracking, and resolving [policy](policies.md) violations.
+For this, there is a second private GitHub repository accessible by administrators and moderators only.
+[Policy](policies.md) violations are always reported publicly to <https://github.com/r-multiverse/help> after they are resolved, without disclosing the identities of the victims or Moderators involved.
+
+The use of these two private repositories ensures that even confidential conversations remain accountable and open to audit.
 
 Private mailing lists are not used by the project.
 


### PR DESCRIPTION
This PR implements https://github.com/r-multiverse/help/issues/120: mentions the [private repository where moderators can confidentially report and discuss policy violations](https://github.com/r-multiverse/moderation).

Set to take effect Feb 10.

When we create email addresses administrators@r-multiverse.org and conduct@r-multiverse.org, we will need to edit this section again.

FYI @maelle, @shikokuchuo, @jeroen.