### PR TITLE
Organize and add to navbar

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -16,16 +16,30 @@ website:
     logo: "logo/logo-hexbin.png"
     logo-alt: "R-multiverse"
     left:
-    - overview.qmd
-    - text: "Repositories"
+    - text: About
+      menu:
+        - text: Overview
+          url: overview.qmd
+        - text: Team
+          url: team.md
+    - text: Repositories
       menu:
         - text: Community
           url: community.md
         - text: Production
           url: production.qmd
-    - contributors.md
-    - moderators.md
-    - team.md
+    - text: Packages
+      menu:
+        - text: Status
+          url: https://r-multiverse.org/status
+        - text: Topics
+          url: https://r-multiverse.org/topics
+    - text: Guidance
+      menu:
+        - text: Community
+          url: contributors.md
+        - text: Moderators
+          url: moderators.md
     - policies.md
     tools:
       - icon: github


### PR DESCRIPTION
This PR adds https://r-multiverse.org/status and https://r-multiverse.org/topics to the navbar (requested by @eitsupi in https://github.com/r-multiverse/help/issues/140), and also groups navbar items into logical categories. Would be great to merge this by Wednesday March 5.