### PR TITLE
Implement PROPOSAL 165: code of conduct update and email

### DIFF
--- a/conduct.md
+++ b/conduct.md
@@ -49,7 +49,7 @@ We agree to restrict the following behaviors in our community. Instances, threat
 Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
 
 When an incident does occur, it is important to report it promptly. To report a possible violation, please email [conduct@r-multiverse.org](mailto:conduct@r-multiverse.org).
-The [R-multiverse administrators](team.md#administrators) have access to this inbox and serve as "Community Moderators" as described below.
+[Will Landau](team.md#will-landau) and [Maëlle Salmon](team.mdl#maëlle-salmon) have access to this inbox, and Will serves as a "Community Moderator" as described below.
 
 Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
 


### PR DESCRIPTION
This pull request implements https://github.com/r-multiverse/help/issues/165:

1. Updates the code of conduct to [Contributor Covenant v3.0](https://www.contributor-covenant.org/version/3/0/code_of_conduct/).
2. Uses `conduct@r-multiverse.org` as the point of contact for reports.

I do realize we have no permanent CoC or committee yet. Currently the [admins](https://r-multiverse.org/team.html) have access to this email and get forwarded copies of reports, but this might not be appropriate or desired. @shikokuchuo, @maelle, and @jeroen, please let me know if you are willing to stay on or if you would like me to remove you from the inbox.

I have a strong preference for using `conduct@r-multiverse.org` as the email, even if I am the only one with access until we get a permanent CoC and committee.

Remarks:

* https://github.com/r-multiverse/help/issues/165 was posted on September 13 2025, so our governance gives us until October 13 2025 to vote on the proposal.
* This PR supersedes #50 and #51.